### PR TITLE
Fix missing fig_top error

### DIFF
--- a/inventario_app.py
+++ b/inventario_app.py
@@ -481,7 +481,9 @@ if "panel" in tab_dict:
                     yaxis_title="Cantidad (abs)",
                     margin=dict(l=40, r=20, t=50, b=40),
                 )
-            st.plotly_chart(fig_top, use_container_width=True)
+                st.plotly_chart(fig_top, use_container_width=True)
+            else:
+                st.info("No hay registros de salidas para mostrar el top de productos.")
 
             # ==== Nuevos gráficos de stock por categoría y tipo ====
             # Si el catálogo tiene una columna "Categoria", mostrar el stock teórico


### PR DESCRIPTION
## Summary
- fix `fig_top` NameError when no "Salida" rows found

## Testing
- `python -m py_compile inventario_app.py`
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688cd48f5454832e97aa5a64cf29a791